### PR TITLE
Switch repo checks to match "splintercommunity"

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -27,7 +27,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main' &&
-      github.repository_owner == 'Cargill'
+      github.repository_owner == 'splintercommunity'
     runs-on: ubuntu-latest
     steps:
       - name: Display envvars


### PR DESCRIPTION
This is necessary after migrating the repos from the Cargill organization.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>